### PR TITLE
Added extra InstrumentedLuisDialog constructors to allow equivalent base class functionality

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -65,7 +65,7 @@ If you are using cognitive services, than you can initialize the singleton as fo
 The call above, will automatically start monitoring your Bots Dialogs and send telemtry to Application Insights.
 
 ### Tracking LUIS intents
-To tack and LUIS intents all you need to do is inherit your Dialog from InstrumentedLuisDialog
+To track any LUIS intents all you need to do is inherit your Dialog from InstrumentedLuisDialog
 ```cs
 [Serializable]
 public class RootDialog : InstrumentedLuisDialog<object>

--- a/botbuilder-instumentation/Dialogs/InstrumentedLuisDialog.cs
+++ b/botbuilder-instumentation/Dialogs/InstrumentedLuisDialog.cs
@@ -16,11 +16,15 @@ namespace BotBuilder.Instrumentation.Dialogs
     [Serializable]
     public class InstrumentedLuisDialog<TResult> : LuisDialog<TResult>
     {
+        public InstrumentedLuisDialog(LuisModelAttribute luisModel) : base(new LuisService(luisModel))
+        {
+        }
+
         public InstrumentedLuisDialog(string luisModelId, string luisSubscriptionKey) : base(new LuisService(new LuisModelAttribute(luisModelId, luisSubscriptionKey)))
         {
         }
 
-        public InstrumentedLuisDialog(string luisModelId, string luisSubscriptionKey, string domain) : base(new LuisService(new LuisModelAttribute(luisModelId, luisSubscriptionKey, LuisApiVersion.V2, domain)))
+        public InstrumentedLuisDialog(string luisModelId, string luisSubscriptionKey, string domain, double threshold = 0) : base(new LuisService(new LuisModelAttribute(luisModelId, luisSubscriptionKey, LuisApiVersion.V2, domain, threshold)))
         {
         }
 


### PR DESCRIPTION
This enables the LUIS version and threshold to be used in the InstrumentedLuisDialog constructor.

I've also noticed that the NuGet package seems to be a bit behind the source code. What's the process for updating it?